### PR TITLE
Fix Linkedin auth

### DIFF
--- a/build/__tests__/models.js
+++ b/build/__tests__/models.js
@@ -182,3 +182,18 @@ test('User.updateAuthentication with existing authentication', async t => {
   t.is(auth.identifier, newAuthentication.identifier);
   t.is(auth.token, newAuthentication.token);
 });
+
+test('User.createWithToken works when the token is really long', async t => {
+  const { User } = models;
+  const authentication = {
+    type: 'linkedin',
+    identifier: 'super-long',
+    token: '12341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234'
+  };
+  const user = await User.createWithAuthentication('longest@bar.baz', authentication);
+  const [actual] = await user.fetchAuthentications();
+
+  t.is(actual.type, authentication.type);
+  t.is(actual.identifier, authentication.identifier);
+  t.is(actual.token, authentication.token);
+});

--- a/migrations/20171127160025_authenticationText.js
+++ b/migrations/20171127160025_authenticationText.js
@@ -1,0 +1,14 @@
+
+exports.up = function(knex, Promise) {
+  return knex.schema.alterTable('authentication', function(t) {
+    t.text('identifier').alter()
+    t.text('token').notNull().alter()
+  })
+};
+
+exports.down = function(knex, Promise) {
+  return knex.schema.alterTable('authentication', function(t) {
+    t.string('identifier').alter()
+    t.string('token').notNull().alter()
+  })
+};

--- a/src/__tests__/models.js
+++ b/src/__tests__/models.js
@@ -182,3 +182,18 @@ test('User.updateAuthentication with existing authentication', async t => {
   t.is(auth.identifier, newAuthentication.identifier)
   t.is(auth.token, newAuthentication.token)
 })
+
+test('User.createWithToken works when the token is really long', async t => {
+  const {User} = models
+  const authentication = {
+    type: 'linkedin',
+    identifier: 'super-long',
+    token: '12341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234',
+  }
+  const user = await User.createWithAuthentication('longest@bar.baz', authentication)
+  const [actual] = await user.fetchAuthentications()
+
+  t.is(actual.type, authentication.type)
+  t.is(actual.identifier, authentication.identifier)
+  t.is(actual.token, authentication.token)
+})


### PR DESCRIPTION
### To reproduce

1. create new application or go to existing application
2. click on 'connect linkedin'

**expected:**
- you go back to application page but the 'connect to linkedin' button is now connected

**actual:**
- you get a blank screen
- the http response code from the server is 500
- the logs show:

```
2017-11-27T15:34:55.328103+00:00 app[web.1]: {"name":"hackcampus-apply","hostname":"2cf58bba-cbb6-451d-a586-2bf51d1c2c5f","pid":40,"level":30,"error":"insert into \"authentication\" (\"identifier\", \"token\", \"type\", \"userId\") values ($1, $2, $3, $4) returning \"id\" - value too long for type character varying(255)","stack":"error: value too long for type character varying(255)\n    at Connection.parseE (/app/node_modules/pg/lib/connection.js:546:11)\n    at Connection.parseMessage (/app/node_modules/pg/lib/connection.js:371:19)\n    at Socket.<anonymous> (/app/node_modules/pg/lib/connection.js:114:22)\n    at emitOne (events.js:115:13)\n    at Socket.emit (events.js:210:7)\n    at addChunk (_stream_readable.js:266:12)\n    at readableAddChunk (_stream_readable.js:253:11)\n    at Socket.Readable.push (_stream_readable.js:211:10)\n    at TCP.onread (net.js:585:20)","msg":"","time":"2017-11-27T15:34:55.327Z","v":0}

```

### The problem

The column types in the authentication table are `character varying(255)` - this is what the Knex `t.string(...)` constructor creates.

Linkedin auth tokens can be longer than that. They used to be 180 bytes long, now they are 350 bytes long - unclear when exactly that changed, but it's reproducible.

### The solution

Changes the column types for the authentication field to `text`, which is what they should have been from the start.
(See https://www.postgresql.org/docs/current/static/datatype-character.html)

### Testing

- Added a unit test with a long token, which fails with the above error.
- Tried to log in to the dev Linkedin app, which succeeded.